### PR TITLE
Refactor APIs to match new generation style in betterproto.

### DIFF
--- a/nitric/api/queues.py
+++ b/nitric/api/queues.py
@@ -24,7 +24,8 @@ from grpclib import GRPCError
 
 from nitric.api.exception import FailedPreconditionException, exception_from_grpc_error, InvalidArgumentException
 from nitric.utils import new_default_channel, _struct_from_dict, _dict_from_struct
-from nitricapi.nitric.queue.v1 import QueueServiceStub, NitricTask, FailedTask as WireFailedTask
+from nitricapi.nitric.queue.v1 import QueueServiceStub, NitricTask, FailedTask as WireFailedTask, QueueCompleteRequest, \
+    QueueSendRequest, QueueSendBatchRequest, QueueReceiveRequest
 from dataclasses import dataclass, field
 
 
@@ -59,7 +60,7 @@ class ReceivedTask(object):
                 "Task is missing internal client or lease id, was it returned from " "queue.receive?"
             )
         try:
-            await self._queueing._queue_stub.complete(queue=self._queue.name, lease_id=self.lease_id)
+            await self._queueing._queue_stub.complete(queue_complete_request=QueueCompleteRequest(queue=self._queue.name, lease_id=self.lease_id))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -149,7 +150,7 @@ class QueueRef(object):
             task = Task(**task)
 
         try:
-            await self._queueing._queue_stub.send(queue=self.name, task=_task_to_wire(task))
+            await self._queueing._queue_stub.send(queue_send_request=QueueSendRequest(queue=self.name, task=_task_to_wire(task)))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -167,7 +168,7 @@ class QueueRef(object):
         wire_tasks = [_task_to_wire(Task(**task) if isinstance(task, dict) else task) for task in tasks]
 
         try:
-            response = await self._queueing._queue_stub.send_batch(queue=self.name, tasks=wire_tasks)
+            response = await self._queueing._queue_stub.send_batch(queue_send_batch_request=QueueSendBatchRequest(queue=self.name, tasks=wire_tasks))
             return [_wire_to_failed_task(failed_task) for failed_task in response.failed_tasks]
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
@@ -190,7 +191,7 @@ class QueueRef(object):
             limit = 1
 
         try:
-            response = await self._queueing._queue_stub.receive(queue=self.name, depth=limit)
+            response = await self._queueing._queue_stub.receive(queue_receive_request=QueueReceiveRequest(queue=self.name, depth=limit))
             # Map the response protobuf response items to Python SDK Nitric Tasks
             return [_wire_to_received_task(task=task, queueing=self._queueing, queue=self) for task in response.tasks]
         except GRPCError as grpc_err:

--- a/nitric/api/secrets.py
+++ b/nitric/api/secrets.py
@@ -24,7 +24,8 @@ from grpclib import GRPCError
 
 from nitric.api.exception import exception_from_grpc_error
 from nitric.utils import new_default_channel
-from nitricapi.nitric.secret.v1 import SecretServiceStub, Secret as SecretMessage, SecretVersion as VersionMessage
+from nitricapi.nitric.secret.v1 import SecretServiceStub, Secret as SecretMessage, SecretVersion as VersionMessage, \
+    SecretPutRequest, SecretAccessRequest
 
 
 class Secrets(object):
@@ -72,7 +73,7 @@ class SecretContainerRef(object):
         secret_message = _secret_to_wire(self)
 
         try:
-            response = await self._secrets._secrets_stub.put(secret=secret_message, value=value)
+            response = await self._secrets._secrets_stub.put(secret_put_request=SecretPutRequest(secret=secret_message, value=value))
             return self.version(version=response.secret_version.version)
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
@@ -111,7 +112,7 @@ class SecretVersion(object):
         """Return the value stored against this version of the secret."""
         version_message = _secret_version_to_wire(self)
         try:
-            response = await self._secrets._secrets_stub.access(secret_version=version_message)
+            response = await self._secrets._secrets_stub.access(secret_access_request=SecretAccessRequest(secret_version=version_message))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/api/storage.py
+++ b/nitric/api/storage.py
@@ -98,7 +98,7 @@ class File(object):
     async def read(self) -> bytes:
         """Read this files contents from the bucket."""
         try:
-            response = await self._storage._storage_stub.read(StorageReadRequest(bucket_name=self._bucket, key=self.key))
+            response = await self._storage._storage_stub.read(storage_read_request=StorageReadRequest(bucket_name=self._bucket, key=self.key))
             return response.body
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
@@ -106,7 +106,7 @@ class File(object):
     async def delete(self):
         """Delete this file from the bucket."""
         try:
-            await self._storage._storage_stub.delete(StorageDeleteRequest(bucket_name=self._bucket, key=self.key))
+            await self._storage._storage_stub.delete(storage_delete_request=StorageDeleteRequest(bucket_name=self._bucket, key=self.key))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/base.py
+++ b/nitric/resources/base.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from asyncio import Task
 
 from typing import TypeVar, Type, Coroutine, Union
 
@@ -33,7 +34,7 @@ class BaseResource(ABC):
 
     def __init__(self):
         """Construct a new resource."""
-        self._reg: Union[Coroutine, None] = None
+        self._reg: Union[Task, None] = None
 
     @abstractmethod
     async def _register(self):
@@ -48,10 +49,10 @@ class BaseResource(ABC):
         """
         # Todo: store the resource reference in a cache to avoid duplicate registrations
         r = cls(name)
-        r._reg = r._register()
+        # r._reg = r._register()
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(r._reg)
+            r._reg = loop.create_task(r._register())
         except RuntimeError:
             loop = asyncio.get_event_loop()
             loop.run_until_complete(r._reg)

--- a/nitric/resources/base.py
+++ b/nitric/resources/base.py
@@ -49,7 +49,6 @@ class BaseResource(ABC):
         """
         # Todo: store the resource reference in a cache to avoid duplicate registrations
         r = cls(name)
-        # r._reg = r._register()
         try:
             loop = asyncio.get_running_loop()
             r._reg = loop.create_task(r._register())

--- a/nitric/resources/buckets.py
+++ b/nitric/resources/buckets.py
@@ -88,7 +88,7 @@ class Bucket(BaseResource):
         """Request the required permissions for this resource."""
         # Ensure registration of the resource is complete before requesting permissions.
         if self._reg is not None:
-            await asyncio.wait({self._reg})
+            await self._reg
 
         policy = PolicyResource(
             principals=[Resource(type=ResourceType.Function)],

--- a/nitric/resources/buckets.py
+++ b/nitric/resources/buckets.py
@@ -33,7 +33,7 @@ from nitricapi.nitric.resource.v1 import (
     ResourceServiceStub,
     PolicyResource,
     ResourceType,
-    Action,
+    Action, ResourceDeclareRequest,
 )
 
 from nitric.resources.base import BaseResource
@@ -80,7 +80,7 @@ class Bucket(BaseResource):
 
     async def _register(self):
         try:
-            await self._resources_stub.declare(resource=_to_resource(self))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=_to_resource(self)))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -96,7 +96,7 @@ class Bucket(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(policy=policy)
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/collections.py
+++ b/nitric/resources/collections.py
@@ -33,7 +33,7 @@ from nitricapi.nitric.resource.v1 import (
     ResourceServiceStub,
     PolicyResource,
     ResourceType,
-    Action,
+    Action, ResourceDeclareRequest,
 )
 
 from nitric.resources.base import BaseResource
@@ -71,13 +71,14 @@ class Collection(BaseResource):
 
     def __init__(self, name: str):
         """Construct a new document collection."""
+        super().__init__()
         self.name = name
         self._channel = new_default_channel()
         self._resources_stub = ResourceServiceStub(channel=self._channel)
 
     async def _register(self):
         try:
-            await self._resources_stub.declare(resource=_to_resource(self))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=_to_resource(self)))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -93,7 +94,7 @@ class Collection(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(policy=policy)
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/collections.py
+++ b/nitric/resources/collections.py
@@ -86,7 +86,7 @@ class Collection(BaseResource):
         """Request the required permissions for this collection."""
         # Ensure registration of the resource is complete before requesting permissions.
         if self._reg is not None:
-            await asyncio.wait({self._reg})
+            await self._reg
 
         policy = PolicyResource(
             principals=[Resource(type=ResourceType.Function)],

--- a/nitric/resources/queues.py
+++ b/nitric/resources/queues.py
@@ -32,7 +32,7 @@ from nitricapi.nitric.resource.v1 import (
     ResourceServiceStub,
     PolicyResource,
     ResourceType,
-    Action,
+    Action, ResourceDeclareRequest,
 )
 
 from nitric.resources.base import BaseResource
@@ -71,13 +71,14 @@ class Queue(BaseResource):
 
     def __init__(self, name: str):
         """Construct a new queue resource."""
+        super().__init__()
         self.name = name
         self._channel = new_default_channel()
         self._resources_stub = ResourceServiceStub(channel=self._channel)
 
     async def _register(self):
         try:
-            await self._resources_stub.declare(resource=_to_resource(self))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=_to_resource(self)))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -93,7 +94,7 @@ class Queue(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(policy=policy)
+            await self._resources_stub.declare(ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/queues.py
+++ b/nitric/resources/queues.py
@@ -86,7 +86,7 @@ class Queue(BaseResource):
         """Request the required permissions for this queue."""
         # Ensure registration of the resource is complete before requesting permissions.
         if self._reg is not None:
-            await asyncio.wait({self._reg})
+            await self._reg
 
         policy = PolicyResource(
             principals=[Resource(type=ResourceType.Function)],

--- a/nitric/resources/queues.py
+++ b/nitric/resources/queues.py
@@ -94,7 +94,7 @@ class Queue(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/secrets.py
+++ b/nitric/resources/secrets.py
@@ -95,7 +95,7 @@ class Secret(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/secrets.py
+++ b/nitric/resources/secrets.py
@@ -87,7 +87,7 @@ class Secret(BaseResource):
         """Request the specified permissions to this resource."""
         # Ensure registration of the resource is complete before requesting permissions.
         if self._reg is not None:
-            await asyncio.wait({self._reg})
+            await self._reg
 
         policy = PolicyResource(
             principals=[Resource(type=ResourceType.Function)],

--- a/nitric/resources/secrets.py
+++ b/nitric/resources/secrets.py
@@ -33,7 +33,7 @@ from nitricapi.nitric.resource.v1 import (
     ResourceServiceStub,
     PolicyResource,
     ResourceType,
-    Action,
+    Action, ResourceDeclareRequest,
 )
 
 from nitric.resources.base import BaseResource
@@ -79,7 +79,7 @@ class Secret(BaseResource):
 
     async def _register(self):
         try:
-            await self._resources_stub.declare(resource=_to_resource(self))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=_to_resource(self)))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -95,7 +95,7 @@ class Secret(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(policy=policy)
+            await self._resources_stub.declare(ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/nitric/resources/topics.py
+++ b/nitric/resources/topics.py
@@ -33,7 +33,7 @@ from nitricapi.nitric.resource.v1 import (
     ResourceServiceStub,
     PolicyResource,
     ResourceType,
-    Action,
+    Action, ResourceDeclareRequest,
 )
 
 from nitric.resources.base import BaseResource
@@ -76,7 +76,7 @@ class Topic(BaseResource):
 
     async def _register(self):
         try:
-            await self._resources_stub.declare(resource=_to_resource(self))
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=_to_resource(self)))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -92,7 +92,7 @@ class Topic(BaseResource):
             resources=[_to_resource(self)],
         )
         try:
-            await self._resources_stub.declare(policy=policy)
+            await self._resources_stub.declare(resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy), policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 

--- a/tests/examples/test_documents_example.py
+++ b/tests/examples/test_documents_example.py
@@ -17,7 +17,8 @@
 # limitations under the License.
 #
 from examples.documents.sub_col_query import documents_sub_col_query
-from nitricapi.nitric.document.v1 import Collection, DocumentGetResponse, DocumentQueryStreamResponse, Document, Key
+from nitricapi.nitric.document.v1 import Collection, DocumentGetResponse, DocumentQueryStreamResponse, Document, Key, \
+    DocumentGetRequest
 from examples.documents.set import documents_set
 from examples.documents.get import documents_get
 from examples.documents.delete import documents_delete
@@ -61,9 +62,11 @@ class DocumentsExamplesTest(IsolatedAsyncioTestCase):
             await documents_get()
 
         mock_get.assert_called_once_with(
-            key=Key(
-                collection=Collection(name="products"),
-                id="nitric",
+            document_get_request=DocumentGetRequest(
+                key=Key(
+                    collection=Collection(name="products"),
+                    id="nitric",
+                )
             )
         )
 

--- a/tests/resources/test_collections.py
+++ b/tests/resources/test_collections.py
@@ -21,7 +21,7 @@ from unittest.mock import patch, AsyncMock
 
 from nitric.resources import collection
 
-from nitricapi.nitric.resource.v1 import Action
+from nitricapi.nitric.resource.v1 import Action, ResourceType, PolicyResource, ResourceDeclareRequest, Resource
 
 from betterproto.lib.google.protobuf import Struct, Value
 
@@ -43,15 +43,17 @@ class CollectionTest(IsolatedAsyncioTestCase):
             await collection("test-collection").allow(["writing"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-collection")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.CollectionDocumentWrite,
-                Action.CollectionList,
-            ],
-        )
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.CollectionDocumentWrite,
+                    Action.CollectionList,
+                ],
+                resources=[Resource(type=ResourceType.Collection, name="test-collection")]
+            )
+        ))
 
     async def test_create_allow_reading(self):
         mock_declare = AsyncMock()
@@ -62,17 +64,18 @@ class CollectionTest(IsolatedAsyncioTestCase):
             await collection("test-collection").allow(["reading"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-collection")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.CollectionDocumentRead,
-                Action.CollectionQuery,
-                Action.CollectionList,
-            ],
-        )
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.CollectionDocumentRead,
+                    Action.CollectionQuery,
+                    Action.CollectionList,
+                ],
+                resources=[Resource(type=ResourceType.Collection, name="test-collection")]
+            )
+        ))
 
     async def test_create_allow_deleting(self):
         mock_declare = AsyncMock()
@@ -83,15 +86,17 @@ class CollectionTest(IsolatedAsyncioTestCase):
             await collection("test-collection").allow(["deleting"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-collection")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.CollectionDocumentDelete,
-                Action.CollectionList,
-            ],
-        )
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.CollectionDocumentDelete,
+                    Action.CollectionList,
+                ],
+                resources=[Resource(type=ResourceType.Collection, name="test-collection")]
+            )
+        ))
 
     async def test_create_allow_all(self):
         mock_declare = AsyncMock()
@@ -102,20 +107,22 @@ class CollectionTest(IsolatedAsyncioTestCase):
             await collection("test-collection").allow(["deleting", "reading", "writing"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-collection")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.CollectionDocumentDelete,
-                Action.CollectionList,
-                Action.CollectionDocumentRead,
-                Action.CollectionQuery,
-                Action.CollectionList,
-                Action.CollectionDocumentWrite,
-                Action.CollectionList,
-            ],
-        )
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.CollectionDocumentDelete,
+                    Action.CollectionList,
+                    Action.CollectionDocumentRead,
+                    Action.CollectionQuery,
+                    Action.CollectionList,
+                    Action.CollectionDocumentWrite,
+                    Action.CollectionList,
+                ],
+                resources=[Resource(type=ResourceType.Collection, name="test-collection")]
+            )
+        ))
 
     async def test_create_allow_all_reversed_policy(self):
         mock_declare = AsyncMock()
@@ -126,77 +133,19 @@ class CollectionTest(IsolatedAsyncioTestCase):
             await collection("test-collection").allow(["writing", "reading", "deleting"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-collection")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.CollectionDocumentWrite,
-                Action.CollectionList,
-                Action.CollectionDocumentRead,
-                Action.CollectionQuery,
-                Action.CollectionList,
-                Action.CollectionDocumentDelete,
-                Action.CollectionList,
-            ],
-        )
-
-    async def test_set_document(self):
-        mock_set = AsyncMock()
-        mock_declare = AsyncMock()
-        mock_response = Object()
-        mock_declare.return_value = mock_response
-
-        with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            with patch("nitricapi.nitric.document.v1.DocumentServiceStub.set", mock_set):
-                collection_a = await collection("a").allow(["writing"])
-                await collection_a.doc("b").set({"a": 1})
-
-        mock_set.assert_called_once_with(
-            key=Key(
-                collection=DocumentCollection(name="a"),
-                id="b",
-            ),
-            content=Struct(
-                fields={
-                    "a": Value(number_value=1.0),
-                },
-            ),
-        )
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.CollectionDocumentWrite,
-                Action.CollectionList,
-            ],
-        )
-
-    async def test_get_document(self):
-        mock_declare = AsyncMock()
-        mock_response = Object()
-        mock_declare.return_value = mock_response
-
-        mock_get = AsyncMock()
-        mock_get.return_value = DocumentGetResponse(
-            document=Document(
-                key=Key(id="b", collection=DocumentCollection(name="a")),
-                content=Struct(
-                    fields={
-                        "a": Value(number_value=1.0),
-                    },
-                ),
-            ),
-        )
-
-        with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            with patch("nitricapi.nitric.document.v1.DocumentServiceStub.get", mock_get):
-                collection_a = await collection("a").allow(["reading"])
-                response = await collection_a.doc("b").get()
-
-        mock_get.assert_called_once_with(
-            key=Key(
-                collection=DocumentCollection(name="a"),
-                id="b",
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.CollectionDocumentWrite,
+                    Action.CollectionList,
+                    Action.CollectionDocumentRead,
+                    Action.CollectionQuery,
+                    Action.CollectionList,
+                    Action.CollectionDocumentDelete,
+                    Action.CollectionList,
+                ],
+                resources=[Resource(type=ResourceType.Collection, name="test-collection")]
             )
-        )
-        self.assertEqual(1.0, response.content["a"])
+        ))

--- a/tests/resources/test_queues.py
+++ b/tests/resources/test_queues.py
@@ -20,7 +20,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, AsyncMock
 from nitric.resources import queue
 
-from nitricapi.nitric.resource.v1 import Action
+from nitricapi.nitric.resource.v1 import Action, ResourceDeclareRequest, Resource, ResourceType, PolicyResource
 from nitric.utils import _struct_from_dict
 
 
@@ -38,16 +38,18 @@ class QueueTest(IsolatedAsyncioTestCase):
             await queue("test-queue").allow(["sending"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-queue")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.QueueSend,
-                Action.QueueList,
-                Action.QueueDetail,
-            ],
-        )
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.QueueSend,
+                    Action.QueueList,
+                    Action.QueueDetail,
+                ],
+                resources=[Resource(type=ResourceType.Queue, name="test-queue")]
+            )
+        ))
 
     async def test_create_allow_receiving(self):
         mock_declare = AsyncMock()
@@ -58,17 +60,18 @@ class QueueTest(IsolatedAsyncioTestCase):
             await queue("test-queue").allow(["receiving"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-queue")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.QueueReceive,
-                Action.QueueList,
-                Action.QueueDetail,
-            ],
-        )
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.QueueReceive,
+                    Action.QueueList,
+                    Action.QueueDetail,
+                ],
+                resources=[Resource(type=ResourceType.Queue, name="test-queue")]
+            )
+        ))
 
     async def test_create_allow_all(self):
         mock_declare = AsyncMock()
@@ -79,38 +82,18 @@ class QueueTest(IsolatedAsyncioTestCase):
             await queue("test-queue").allow(["sending", "receiving"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-queue")
-        self.assertListEqual(
-            mock_declare.call_args.kwargs["policy"].actions,
-            [
-                Action.QueueSend,
-                Action.QueueList,
-                Action.QueueDetail,
-                Action.QueueReceive,
-                Action.QueueList,
-                Action.QueueDetail,
-            ],
-        )
-
-    async def test_send_dict(self):
-        mock_send = AsyncMock()
-        mock_declare = AsyncMock()
-
-        mock_response = Object()
-        mock_send.return_value = mock_response
-
-        payload = {"content": "of task"}
-
-        with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            with patch("nitricapi.nitric.queue.v1.QueueServiceStub.send", mock_send):
-                q = await queue("test-queue").allow(["sending"])
-                await q.send({"id": "123", "payload": payload})
-
-        # Check expected values were passed to Stub
-        mock_send.assert_called_once()
-        self.assertEqual(mock_send.call_args.kwargs["queue"], "test-queue")
-        self.assertEqual(mock_send.call_args.kwargs["task"].id, "123")
-        self.assertIsNone(mock_send.call_args.kwargs["task"].payload_type)
-        self.assertEqual(len(mock_send.call_args.kwargs["task"].payload.fields), 1)
-        self.assertEqual(mock_send.call_args.kwargs["task"].payload, _struct_from_dict(payload))
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.QueueSend,
+                    Action.QueueList,
+                    Action.QueueDetail,
+                    Action.QueueReceive,
+                    Action.QueueList,
+                    Action.QueueDetail,
+                ],
+                resources=[Resource(type=ResourceType.Queue, name="test-queue")]
+            )
+        ))

--- a/tests/resources/test_secrets.py
+++ b/tests/resources/test_secrets.py
@@ -20,7 +20,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, AsyncMock
 from nitric.resources import secret
 
-from nitricapi.nitric.resource.v1 import Action
+from nitricapi.nitric.resource.v1 import Action, ResourceDeclareRequest, Resource, ResourceType, PolicyResource
 from nitricapi.nitric.secret.v1 import SecretPutResponse, SecretVersion, Secret
 
 
@@ -38,9 +38,17 @@ class SecretTest(IsolatedAsyncioTestCase):
             await secret("test-secret").allow(["putting"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-secret")
-        self.assertListEqual(mock_declare.call_args.kwargs["policy"].actions, [Action.SecretPut])
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.SecretPut
+                ],
+                resources=[Resource(type=ResourceType.Secret, name="test-secret")]
+            )
+        ))
+
 
     async def test_allow_access(self):
         mock_declare = AsyncMock()
@@ -51,24 +59,13 @@ class SecretTest(IsolatedAsyncioTestCase):
             await secret("test-secret").allow(["accessing"])
 
         # Check expected values were passed to Stub
-        mock_declare.assert_called()
-        self.assertEqual(mock_declare.call_args.kwargs["policy"].resources[0].name, "test-secret")
-        self.assertListEqual(mock_declare.call_args.kwargs["policy"].actions, [Action.SecretAccess])
-
-    async def test_put_string(self):
-        mock_put = AsyncMock()
-        mock_declare = AsyncMock()
-
-        mock_response = SecretPutResponse(
-            secret_version=SecretVersion(secret=Secret(name="test-secret"), version="test-version")
-        )
-        mock_put.return_value = mock_response
-
-        with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            with patch("nitricapi.nitric.secret.v1.SecretServiceStub.put", mock_put):
-                s = await secret("test-secret").allow(["accessing"])
-                await s.put("a test secret value")  # string, not bytes
-
-        # Check expected values were passed to Stub
-        mock_put.assert_called_once()
-        assert mock_put.call_args.kwargs["value"] == b"a test secret value"  # value should still be bytes when sent.
+        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
+            resource=Resource(type=ResourceType.Policy),
+            policy=PolicyResource(
+                principals=[Resource(type=ResourceType.Function)],
+                actions=[
+                    Action.SecretAccess
+                ],
+                resources=[Resource(type=ResourceType.Secret, name="test-secret")]
+            )
+        ))


### PR DESCRIPTION
see release note here: https://github.com/danielgtaylor/python-betterproto/releases/tag/v2.0.0b5

For why this change is made.