### PR TITLE
Make allow methods synchronous

### DIFF
--- a/nitric/resources/apis.py
+++ b/nitric/resources/apis.py
@@ -124,9 +124,6 @@ class Api(BaseResource):
         self.security_definitions = opts.security_definitions
         self.security = opts.security
 
-        self._channel = new_default_channel()
-        self._resources_stub = ResourceServiceStub(channel=self._channel)
-
     async def _register(self):
         try:
             await self._resources_stub.declare(

--- a/nitric/resources/base.py
+++ b/nitric/resources/base.py
@@ -94,13 +94,8 @@ class SecureResource(BaseResource):
                                                                 policy=policy))
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
-        pass
 
     def _register_policy(self, permissions: List[str]):
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self._register_policy_async(permissions))
-        except RuntimeError:
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(self._register_policy_async(permissions))
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self._register_policy_async(permissions))
 

--- a/nitric/resources/base.py
+++ b/nitric/resources/base.py
@@ -22,7 +22,14 @@ import asyncio
 from abc import ABC, abstractmethod
 from asyncio import Task
 
-from typing import TypeVar, Type, Coroutine, Union
+from typing import TypeVar, Type, Coroutine, Union, List
+
+from grpclib import GRPCError
+from nitricapi.nitric.resource.v1 import Action, PolicyResource, Resource, ResourceType, ResourceDeclareRequest, \
+    ResourceServiceStub
+
+from nitric.api.exception import exception_from_grpc_error
+from nitric.utils import new_default_channel
 
 T = TypeVar("T", bound="BaseResource")
 
@@ -35,6 +42,8 @@ class BaseResource(ABC):
     def __init__(self):
         """Construct a new resource."""
         self._reg: Union[Task, None] = None
+        self._channel = new_default_channel()
+        self._resources_stub = ResourceServiceStub(channel=self._channel)
 
     @abstractmethod
     async def _register(self):
@@ -57,3 +66,41 @@ class BaseResource(ABC):
             loop.run_until_complete(r._register())
 
         return r
+
+
+class SecureResource(BaseResource):
+    """A secure base resource class"""
+
+    @abstractmethod
+    def _to_resource(self) -> Resource:
+        pass
+
+    @abstractmethod
+    def _perms_to_actions(self, permissions: List[str]) -> List[Action]:
+        pass
+
+    async def _register_policy_async(self, permissions: List[str]):
+        # if self._reg is not None:
+        #     await asyncio.wait({self._reg})
+
+        policy = PolicyResource(
+            principals=[Resource(type=ResourceType.Function)],
+            actions=self._perms_to_actions(permissions),
+            resources=[self._to_resource()],
+        )
+        try:
+            await self._resources_stub.declare(
+                resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy),
+                                                                policy=policy))
+        except GRPCError as grpc_err:
+            raise exception_from_grpc_error(grpc_err)
+        pass
+
+    def _register_policy(self, permissions: List[str]):
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._register_policy_async(permissions))
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(self._register_policy_async(permissions))
+

--- a/tests/resources/test_buckets.py
+++ b/tests/resources/test_buckets.py
@@ -31,7 +31,7 @@ class Object(object):
 
 
 class BucketTest(IsolatedAsyncioTestCase):
-    async def test_create_allow_writing(self):
+    def test_create_allow_writing(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -49,7 +49,7 @@ class BucketTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_reading(self):
+    def test_create_allow_reading(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -67,7 +67,7 @@ class BucketTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_deleting(self):
+    def test_create_allow_deleting(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -85,7 +85,7 @@ class BucketTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_all(self):
+    def test_create_allow_all(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -108,7 +108,7 @@ class BucketTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_all_reversed_policy(self):
+    def test_create_allow_all_reversed_policy(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -131,37 +131,3 @@ class BucketTest(IsolatedAsyncioTestCase):
             )
         ))
 
-
-    async def test_write(self):
-        mock_declare = AsyncMock()
-        mock_write = AsyncMock()
-        mock_response = Object()
-        mock_declare.return_value = mock_response
-
-        contents = b"some text as bytes"
-
-        with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            with patch("nitricapi.nitric.storage.v1.StorageServiceStub.write", mock_write):
-                b = bucket("test-bucket").allow(["writing"])
-                file = b.file("test-file")
-                await file.write(contents)
-
-        # Check expected resources were declared
-        mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
-            resource=Resource(type=ResourceType.Policy),
-            policy=PolicyResource(
-                principals=[Resource(type=ResourceType.Function)],
-                actions=[
-                    Action.BucketFilePut,
-                ],
-                resources=[Resource(type=ResourceType.Bucket, name="test-bucket")]
-            )
-        ))
-
-        # Check correct data was written
-        mock_write.assert_called_with(storage_write_request=StorageWriteRequest(
-            bucket_name="test-bucket",
-            key="test-file",
-            body=contents
-
-        ))

--- a/tests/resources/test_buckets.py
+++ b/tests/resources/test_buckets.py
@@ -37,7 +37,7 @@ class BucketTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await bucket("test-bucket").allow(["writing"])
+            bucket("test-bucket").allow(["writing"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -55,7 +55,7 @@ class BucketTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await bucket("test-bucket").allow(["reading"])
+            bucket("test-bucket").allow(["reading"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -73,7 +73,7 @@ class BucketTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await bucket("test-bucket").allow(["deleting"])
+            bucket("test-bucket").allow(["deleting"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -91,7 +91,7 @@ class BucketTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await bucket("test-bucket").allow(["deleting", "reading", "writing"])
+            bucket("test-bucket").allow(["deleting", "reading", "writing"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -114,7 +114,7 @@ class BucketTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await bucket("test-bucket").allow(["writing", "reading", "deleting"])
+            bucket("test-bucket").allow(["writing", "reading", "deleting"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -142,7 +142,7 @@ class BucketTest(IsolatedAsyncioTestCase):
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
             with patch("nitricapi.nitric.storage.v1.StorageServiceStub.write", mock_write):
-                b = await bucket("test-bucket").allow(["writing"])
+                b = bucket("test-bucket").allow(["writing"])
                 file = b.file("test-file")
                 await file.write(contents)
 

--- a/tests/resources/test_collections.py
+++ b/tests/resources/test_collections.py
@@ -40,7 +40,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await collection("test-collection").allow(["writing"])
+            collection("test-collection").allow(["writing"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -61,7 +61,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await collection("test-collection").allow(["reading"])
+            collection("test-collection").allow(["reading"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -83,7 +83,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await collection("test-collection").allow(["deleting"])
+            collection("test-collection").allow(["deleting"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -104,7 +104,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await collection("test-collection").allow(["deleting", "reading", "writing"])
+            collection("test-collection").allow(["deleting", "reading", "writing"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -130,7 +130,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await collection("test-collection").allow(["writing", "reading", "deleting"])
+            collection("test-collection").allow(["writing", "reading", "deleting"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(

--- a/tests/resources/test_collections.py
+++ b/tests/resources/test_collections.py
@@ -34,7 +34,7 @@ class Object(object):
 
 
 class CollectionTest(IsolatedAsyncioTestCase):
-    async def test_create_allow_writing(self):
+    def test_create_allow_writing(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -55,7 +55,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_reading(self):
+    def test_create_allow_reading(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -77,7 +77,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_deleting(self):
+    def test_create_allow_deleting(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -98,7 +98,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_all(self):
+    def test_create_allow_all(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -124,7 +124,7 @@ class CollectionTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_all_reversed_policy(self):
+    def test_create_allow_all_reversed_policy(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response

--- a/tests/resources/test_queues.py
+++ b/tests/resources/test_queues.py
@@ -29,7 +29,7 @@ class Object(object):
 
 
 class QueueTest(IsolatedAsyncioTestCase):
-    async def test_create_allow_sending(self):
+    def test_create_allow_sending(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -51,7 +51,7 @@ class QueueTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_receiving(self):
+    def test_create_allow_receiving(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -73,7 +73,7 @@ class QueueTest(IsolatedAsyncioTestCase):
             )
         ))
 
-    async def test_create_allow_all(self):
+    def test_create_allow_all(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response

--- a/tests/resources/test_queues.py
+++ b/tests/resources/test_queues.py
@@ -35,7 +35,7 @@ class QueueTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await queue("test-queue").allow(["sending"])
+            queue("test-queue").allow(["sending"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -57,7 +57,7 @@ class QueueTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await queue("test-queue").allow(["receiving"])
+            queue("test-queue").allow(["receiving"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -79,7 +79,7 @@ class QueueTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await queue("test-queue").allow(["sending", "receiving"])
+            queue("test-queue").allow(["sending", "receiving"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(

--- a/tests/resources/test_secrets.py
+++ b/tests/resources/test_secrets.py
@@ -29,7 +29,7 @@ class Object(object):
 
 
 class SecretTest(IsolatedAsyncioTestCase):
-    async def test_allow_put(self):
+    def test_allow_put(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response
@@ -50,7 +50,7 @@ class SecretTest(IsolatedAsyncioTestCase):
         ))
 
 
-    async def test_allow_access(self):
+    def test_allow_access(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response

--- a/tests/resources/test_secrets.py
+++ b/tests/resources/test_secrets.py
@@ -35,7 +35,7 @@ class SecretTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await secret("test-secret").allow(["putting"])
+            secret("test-secret").allow(["putting"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(
@@ -56,7 +56,7 @@ class SecretTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await secret("test-secret").allow(["accessing"])
+            secret("test-secret").allow(["accessing"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(

--- a/tests/resources/test_topics.py
+++ b/tests/resources/test_topics.py
@@ -36,7 +36,7 @@ class MockAsyncChannel:
 
 
 class TopicTest(IsolatedAsyncioTestCase):
-    async def test_create_allow_publishing(self):
+    def test_create_allow_publishing(self):
         mock_declare = AsyncMock()
         mock_response = Object()
         mock_declare.return_value = mock_response

--- a/tests/resources/test_topics.py
+++ b/tests/resources/test_topics.py
@@ -18,10 +18,10 @@
 #
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, AsyncMock, Mock
-from nitric.resources import topic
 
 from nitricapi.nitric.resource.v1 import Action, ResourceDeclareRequest, Resource, ResourceType, PolicyResource
-from nitric.utils import _struct_from_dict
+
+from nitric.resources import topic
 
 
 class Object(object):
@@ -42,7 +42,7 @@ class TopicTest(IsolatedAsyncioTestCase):
         mock_declare.return_value = mock_response
 
         with patch("nitricapi.nitric.resource.v1.ResourceServiceStub.declare", mock_declare):
-            await topic("test-topic").allow(["publishing"])
+            topic("test-topic").allow(["publishing"])
 
         # Check expected values were passed to Stub
         mock_declare.assert_called_with(resource_declare_request=ResourceDeclareRequest(


### PR DESCRIPTION
Need `allow` methods on resources to be synchronous so resource references can be accessed immediately.