### PR TITLE
Provide more informative error when resources are declared at runtime

### DIFF
--- a/nitric/api/exception.py
+++ b/nitric/api/exception.py
@@ -141,6 +141,8 @@ class UnknownException(NitricServiceException):
 
     pass
 
+class NitricResourceException(Exception):
+    pass
 
 def exception_from_grpc_error(error: GRPCError):
     """Translate a gRPC error to a nitric api exception."""

--- a/nitric/resources/base.py
+++ b/nitric/resources/base.py
@@ -25,8 +25,14 @@ from asyncio import Task
 from typing import TypeVar, Type, Union, List
 
 from grpclib import GRPCError
-from nitricapi.nitric.resource.v1 import Action, PolicyResource, Resource, ResourceType, ResourceDeclareRequest, \
-    ResourceServiceStub
+from nitricapi.nitric.resource.v1 import (
+    Action,
+    PolicyResource,
+    Resource,
+    ResourceType,
+    ResourceDeclareRequest,
+    ResourceServiceStub,
+)
 
 from nitric.api.exception import exception_from_grpc_error, NitricResourceException
 from nitric.utils import new_default_channel
@@ -69,7 +75,7 @@ class BaseResource(ABC):
 
 
 class SecureResource(BaseResource):
-    """A secure base resource class"""
+    """A secure base resource class."""
 
     @abstractmethod
     def _to_resource(self) -> Resource:
@@ -90,8 +96,10 @@ class SecureResource(BaseResource):
         )
         try:
             await self._resources_stub.declare(
-                resource_declare_request=ResourceDeclareRequest(resource=Resource(type=ResourceType.Policy),
-                                                                policy=policy))
+                resource_declare_request=ResourceDeclareRequest(
+                    resource=Resource(type=ResourceType.Policy), policy=policy
+                )
+            )
         except GRPCError as grpc_err:
             raise exception_from_grpc_error(grpc_err)
 
@@ -101,6 +109,7 @@ class SecureResource(BaseResource):
             loop.run_until_complete(self._register_policy_async(*args))
         except RuntimeError:
             # TODO: Check nitric runtime ENV variable
-            raise NitricResourceException("Nitric resource declared at runtime! Move resource declarations to top level of scripts")
-
-
+            raise NitricResourceException(
+                "Nitric resources cannot be declared at runtime e.g. within the scope of a function. \
+                    Move resource declarations to the top level of scripts so that they can be safely provisioned"
+            )

--- a/nitric/resources/base.py
+++ b/nitric/resources/base.py
@@ -28,7 +28,7 @@ from grpclib import GRPCError
 from nitricapi.nitric.resource.v1 import Action, PolicyResource, Resource, ResourceType, ResourceDeclareRequest, \
     ResourceServiceStub
 
-from nitric.api.exception import exception_from_grpc_error
+from nitric.api.exception import exception_from_grpc_error, NitricResourceException
 from nitric.utils import new_default_channel
 
 T = TypeVar("T", bound="BaseResource")
@@ -96,6 +96,11 @@ class SecureResource(BaseResource):
             raise exception_from_grpc_error(grpc_err)
 
     def _register_policy(self, *args: str):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self._register_policy_async(*args))
+        try:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(self._register_policy_async(*args))
+        except RuntimeError:
+            # TODO: Check nitric runtime ENV variable
+            raise NitricResourceException("Nitric resource declared at runtime! Move resource declarations to top level of scripts")
+
 


### PR DESCRIPTION
Declaring resources in callbacks in an illegal operation. Raising a custom exception type to try and provide clearer guidance. We should link to a document explaining why and what to do when encountering this kind of error.