### PR TITLE
re-export ApiOptions and Method options on resources.

### DIFF
--- a/nitric/resources/__init__.py
+++ b/nitric/resources/__init__.py
@@ -18,7 +18,7 @@
 #
 """Nitric Python SDK API Documentation. See: https://nitric.io/docs?lang=python for full framework documentation."""
 
-from nitric.resources.apis import Api, api
+from nitric.resources.apis import Api, api, MethodOptions, ApiOptions
 from nitric.resources.buckets import Bucket, bucket
 from nitric.resources.collections import Collection, collection
 from nitric.resources.queues import Queue, queue
@@ -29,6 +29,8 @@ from nitric.resources.topics import Topic, topic
 __all__ = [
     "api",
     "Api",
+    "ApiOptions",
+    "MethodOptions",
     "bucket",
     "Bucket",
     "collection",


### PR DESCRIPTION
Re-exporting these for visibility and to match docs. As an alternative we can flatten these options objects as named parameters. 