### PR TITLE
feat: Handle JWT tokens

### DIFF
--- a/nitric/auth.py
+++ b/nitric/auth.py
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2021 Nitric Technologies Pty Ltd.
+#
+# This file is part of Nitric Python 3 SDK.
+# See https://github.com/nitrictech/python-sdk for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from abc import ABC, abstractmethod
+from typing import Optional
+import jwt
+
+from nitric.context import HttpContext, HttpMiddleware
+from nitric.resources.apis import ApiOptions
+
+
+class AuthMiddleware(ABC):
+    """Abstract base class for authentication middleware."""
+
+    @abstractmethod
+    async def __call__(self, ctx: HttpContext, nxt: HttpMiddleware) -> HttpContext:
+        """Process the request and response."""
+        pass
+
+    @abstractmethod
+    def get_auth_token(self, ctx: HttpContext) -> Optional[str]:
+        """Retrieve the authentication token from the request."""
+        pass
+
+    @abstractmethod
+    def authenticate(self, token: str) -> Optional[dict]:
+        """Authenticate the provided token and return the user info."""
+        pass
+
+    async def authenticate_request(self, ctx: HttpContext) -> None:
+        """Process the request, authenticate the user and set the user info."""
+        token = self.get_auth_token(ctx)
+        ctx.req.user = None  # Set user to None by default
+
+        if token:
+            user_info = self.authenticate(token)
+            if user_info:
+                ctx.req.user = user_info
+            else:
+                ctx.res.status = 401
+                ctx.res.body = {"error": "Invalid token"}
+        else:
+            ctx.res.status = 401
+            ctx.res.body = {"error": "Missing token"}
+
+
+class JWTAuthMiddleware(AuthMiddleware):
+    """JWT authentication middleware."""
+
+    def __init__(self, api_options: ApiOptions):
+        """Initialize the middleware with the provided secret and algorithm."""
+        self.secret = api_options.jwt_secret
+        self.algorithm = api_options.jwt_algorithm
+
+    async def __call__(self, ctx: HttpContext, nxt: HttpMiddleware) -> HttpContext:
+        """Process the request and response."""
+        await self.authenticate_request(ctx)
+        if ctx.res.status != 401:
+            ctx = await nxt(ctx)
+        return ctx
+
+    def get_auth_token(self, ctx: HttpContext) -> Optional[str]:
+        """Retrieve the JWT token from the Authorization header."""
+        auth_header = ctx.req.headers.get("Authorization")
+        if auth_header:
+            if isinstance(auth_header, list):
+                auth_header = auth_header[0]
+            if auth_header.startswith("Bearer "):
+                return auth_header[7:]
+        return None
+
+    def authenticate(self, token: str) -> Optional[dict]:
+        """Decode the JWT token and return the payload."""
+        try:
+            payload = jwt.decode(token, self.secret, algorithms=[self.algorithm])
+            return payload
+        except jwt.InvalidTokenError:
+            return None

--- a/nitric/resources/apis.py
+++ b/nitric/resources/apis.py
@@ -113,6 +113,8 @@ class ApiOptions:
         path: str = "",
         middleware: Optional[Union[HttpMiddleware, List[HttpMiddleware]]] = None,
         security: Optional[List[ScopedOidcOptions]] = None,
+        jwt_secret: Optional[str] = None,
+        jwt_algorithm: Optional[str] = None,
     ):
         """Construct a new API options object."""
         if middleware is None:
@@ -122,6 +124,8 @@ class ApiOptions:
         self.middleware = middleware
         self.security = security
         self.path = path
+        self.jwt_secret = jwt_secret
+        self.jwt_algorithm = jwt_algorithm
 
 
 class RouteOptions:
@@ -342,12 +346,8 @@ class Route:
         self, methods: List[HttpMethod], *middleware: HttpMiddleware | HttpHandler, opts: Optional[MethodOptions] = None
     ) -> None:
         """Register middleware for multiple HTTP Methods."""
-
         # ensure route/api middlewares are added
-        middleware = (
-            *self.middleware,
-            *middleware
-        )
+        middleware = (*self.middleware, *middleware)
 
         Method(self, methods, *middleware, opts=opts if opts else MethodOptions())
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setuptools.setup(
             "grpcio-tools==1.62.0",
             "twine==3.2.0",
             "mypy==1.3.0",
+            "pyjwt==2.8.0",
         ]
     },
     python_requires=">=3.11",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2021 Nitric Technologies Pty Ltd.
+#
+# This file is part of Nitric Python 3 SDK.
+# See https://github.com/nitrictech/python-sdk for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+from nitric.auth import JWTAuthMiddleware
+from nitric.resources.apis import ApiOptions
+from nitric.context import HttpContext, HttpRequest, HttpResponse
+
+
+class TestJWTAuthMiddleware(IsolatedAsyncioTestCase):
+    async def test_valid_token(self):
+        secret = "secret"
+        algorithm = "HS256"
+        api_options = ApiOptions(jwt_secret=secret, jwt_algorithm=algorithm)
+        middleware = JWTAuthMiddleware(api_options=api_options)
+
+        token = jwt.encode({"sub": "user123"}, secret, algorithm=algorithm)
+
+        request = HttpRequest(
+            data=b"", method="GET", path="/", params={}, query={}, headers={"Authorization": f"Bearer {token}"}
+        )
+        context = HttpContext(request=request)
+
+        mock_next = AsyncMock(return_value=context)
+
+        result = await middleware(context, mock_next)
+
+        mock_next.assert_awaited_once_with(context)
+        self.assertEqual(result.req.user, {"sub": "user123"})
+
+    async def test_missing_token(self):
+        api_options = ApiOptions(jwt_secret="secret", jwt_algorithm="HS256")
+        middleware = JWTAuthMiddleware(api_options=api_options)
+
+        request = HttpRequest(data=b"", method="GET", path="/", params={}, query={}, headers={})
+        context = HttpContext(request=request)
+
+        mock_next = AsyncMock()
+
+        result = await middleware(context, mock_next)
+
+        mock_next.assert_not_awaited()
+        self.assertEqual(result.res.status, 401)
+        self.assertEqual(result.res.body, b'{"error": "Missing token"}')
+
+    async def test_invalid_token(self):
+        api_options = ApiOptions(jwt_secret="secret", jwt_algorithm="HS256")
+        middleware = JWTAuthMiddleware(api_options=api_options)
+
+        request = HttpRequest(
+            data=b"", method="GET", path="/", params={}, query={}, headers={"Authorization": "Bearer invalid_token"}
+        )
+        context = HttpContext(request=request)
+
+        mock_next = AsyncMock()
+
+        result = await middleware(context, mock_next)
+
+        mock_next.assert_not_awaited()
+        self.assertEqual(result.res.status, 401)
+        self.assertEqual(result.res.body, b'{"error": "Invalid token"}')


### PR DESCRIPTION
This change allows users to pass JWT secret and algorithm values when creating an API with JWT authentication middleware, like this:

```python

api_options = ApiOptions(jwt_secret="your_secret_key", jwt_algorithm="HS256")
my_api = api("my-api", ApiOptions(
    middleware=[
        JWTAuthMiddleware(api_options)
    ]
))
```

This addition suggests a potential future enhancement to allow users to define the JWT secret and algorithm values in the `nitric.yaml` configuration file.