### PR TITLE
fix: parse topic events without struct fields

### DIFF
--- a/nitric/context.py
+++ b/nitric/context.py
@@ -31,6 +31,7 @@ from nitric.proto.schedules.v1 import ServerMessage as ScheduleServerMessage
 from nitric.proto.topics.v1 import ClientMessage as TopicClientMessage
 from nitric.proto.topics.v1 import MessageResponse as TopicResponse
 from nitric.proto.topics.v1 import ServerMessage as TopicServerMessage
+from nitric.utils import dict_from_struct
 
 Record = Dict[str, Union[str, List[str]]]
 PROPAGATOR = propagate.get_global_textmap()
@@ -173,7 +174,7 @@ class MessageContext:
         """Construct a new EventContext from a Topic trigger from the Nitric Membrane."""
         return MessageContext(
             request=MessageRequest(
-                data=msg.message_request.message.struct_payload.to_dict(),
+                data=dict_from_struct(msg.message_request.message.struct_payload),
                 topic=msg.message_request.topic_name,
             )
         )

--- a/nitric/resources/topics.py
+++ b/nitric/resources/topics.py
@@ -37,7 +37,7 @@ from nitric.proto.topics.v1 import MessageResponse as ProtoMessageResponse
 from nitric.proto.topics.v1 import RegistrationRequest, SubscriberStub
 from nitric.proto.topics.v1 import TopicPublishRequest, TopicsStub
 from nitric.resources.resource import SecureResource
-from nitric.utils import new_default_channel, struct_from_dict
+from nitric.utils import dict_from_struct, new_default_channel, struct_from_dict
 
 TopicPermission = Literal["publish"]
 
@@ -131,7 +131,7 @@ class Topic(SecureResource):
 def _message_context_from_proto(msg: ProtoMessageRequest) -> MessageContext:
     return MessageContext(
         request=MessageRequest(
-            data=msg.message.struct_payload.to_dict(),
+            data=dict_from_struct(msg.message.struct_payload),
             topic=msg.topic_name,
         )
     )


### PR DESCRIPTION
Using to_dict on the struct includes internal fields from the protobuf struct, instead of a standard python dictionary
